### PR TITLE
JBIDE-15792 - JPP 6.1 project does not contain JBoss Portlet Libraries

### DIFF
--- a/plugins/org.jboss.tools.portlet.core/src/org/jboss/tools/portlet/core/IPortletConstants.java
+++ b/plugins/org.jboss.tools.portlet.core/src/org/jboss/tools/portlet/core/IPortletConstants.java
@@ -84,6 +84,8 @@ public interface IPortletConstants {
 	static final String SERVER_DEFAULT_DEPLOY_GATEIN33 = "standalone/deployments/gatein.ear"; //$NON-NLS-1$
 	
 	static final String SERVER_DEFAULT_DEPLOY_JPP60 = "gatein/gatein.ear"; //$NON-NLS-1$
+
+	static final String MODULES_JAVAX_PORTLET_API_JPP61a = "modules/system/layers/gatein/javax/portlet/api/main/"; //$NON-NLS-1$
 	
 
 	static final String GATEIN_MODULES_JAVAX_PORTLET_API_MAIN = "gatein/modules/javax/portlet/api/main"; //$NON-NLS-1$

--- a/plugins/org.jboss.tools.portlet.core/src/org/jboss/tools/portlet/core/internal/PortletRuntimeLibrariesContainerInitializer.java
+++ b/plugins/org.jboss.tools.portlet.core/src/org/jboss/tools/portlet/core/internal/PortletRuntimeLibrariesContainerInitializer.java
@@ -158,7 +158,8 @@ public class PortletRuntimeLibrariesContainerInitializer extends
 					IPortletConstants.GATEIN_MODULES_JAVAX_PORTLET_API_MAIN,
 					IPortletConstants.MODULES_JAVAX_PORTLET_API_MAIN,
 					IPortletConstants.MODULES_JAVAX_PORTLET_API_MAIN72,
-					IPortletConstants.MODULES_JAVAX_PORTLET_API_JPP61
+					IPortletConstants.MODULES_JAVAX_PORTLET_API_JPP61,
+					IPortletConstants.MODULES_JAVAX_PORTLET_API_JPP61a 
 			};
 			File file = jbossLocation.toFile();
 			for (String dir:directories2) {


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-15792
JPP 6.1 project does not contain JBoss Portlet Libraries
