### PR TITLE
JBIDE-11436 - Migrate to use of o.j.t.foundation.license feature

### DIFF
--- a/features/org.jboss.tools.portlet.feature/feature.properties
+++ b/features/org.jboss.tools.portlet.feature/feature.properties
@@ -30,20 +30,3 @@ description=JBoss Portlet provides a set of project wizards to help support sett
 copyright=Copyright (c) 2008-2014 Red Hat, Inc. and others.\nAll rights reserved. This program and the accompanying materials\n\
 are made available under the terms of the Eclipse Public License v1.0\nwhich accompanies this distribution, and is available at\nhttp\://www.eclipse.org/legal/epl-v10.html\n\nContributors\:\nJBoss by Red Hat - Initial implementation.\n
  ############### end of copyright property ####################################
-
-# "licenseURL" property - URL of the "Feature License"
-# do not translate value - just change to point to a locale-specific HTML page
-licenseURL=license.html
-
-# START NON-TRANSLATABLE
-# "license" property - text of the "Feature Update License"
-# should be plain text version of license agreement pointed to be "licenseURL"
-license=Red Hat, Inc. licenses these features and plugins to you under \
-certain open source licenses (or aggregations of such licenses), which \
-in a particular case may include the Eclipse Public License, the GNU \
-Lesser General Public License, and/or certain other open source \
-licenses. For precise licensing details, consult the corresponding \
-source code, or contact Red Hat Legal Affairs, 1801 Varsity Drive, \
-Raleigh NC 27606 USA.
-# END NON-TRANSLATABLE
-########### end of license property ##########################################

--- a/features/org.jboss.tools.portlet.feature/feature.xml
+++ b/features/org.jboss.tools.portlet.feature/feature.xml
@@ -4,6 +4,8 @@
       label="%featureName"
       version="1.6.100.qualifier"
       provider-name="%providerName"
+      license-feature="org.jboss.tools.foundation.license.feature"
+      license-feature-version="0.0.0"
       plugin="org.jboss.tools.portlet.ui">
 
    <description>
@@ -14,7 +16,7 @@
       %copyright
    </copyright>
 
-   <license url="%licenseURL">
+   <license>
       %license
    </license>
 

--- a/features/org.jboss.tools.portlet.feature/feature_ja.properties
+++ b/features/org.jboss.tools.portlet.feature/feature_ja.properties
@@ -4,4 +4,3 @@ updateSiteName=JBossTools Update Site
 description=JBoss \u30DD\u30FC\u30C8\u30EC\u30C3\u30C8
 copyright=Copyright (c) 2008-2014 JBoss by Red Hat and others.\nAll rights reserved. This program and the accompanying materials\n 
 are=made available under the terms of the Eclipse Public License v1.0which accompanies this distribution, and is available athttp//www.eclipse.org/legal/epl-v10.htmlContributorsJBoss by Red Hat - Initial implementation.
-licenseURL=license.html

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.3.0.Beta1-SNAPSHOT</version>
+		<version>4.3.0.Beta2-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>portlet</artifactId>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-11436
Migrate to use of o.j.t.foundation.license feature